### PR TITLE
Fix set breakpoint in files in subdirectories

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -73,7 +73,7 @@ class WebPdbTestCase(SeleniumTestCase):
         Test back-end/front-end interaction during debugging
         """
         filename_tag = self.browser.find_element_by_id('filename')
-        self.assertEqual(filename_tag.text, 'db.py')
+        self.assertEqual(filename_tag.text.split(os.path.sep)[-1], 'db.py')
         curr_line_tag = self.browser.find_element_by_id('curr_line')
         self.assertEqual(curr_line_tag.text, '14')
         curr_file_tag = self.browser.find_element_by_id('curr_file_code')

--- a/web_pdb/__init__.py
+++ b/web_pdb/__init__.py
@@ -146,7 +146,7 @@ class WebPdb(Pdb):
         if sys.version_info[0] == 2:
             lines = [line.decode('utf-8') for line in lines]
         return {
-            'filename': os.path.basename(filename),
+            'filename': filename,
             'file_listing': ''.join(lines),
             'current_line': self.curframe.f_lineno,
             'total_lines': len(lines),


### PR DESCRIPTION
Click to set breakpoint did not work when the current file was in a subdirectory. basename removed this.

Removal of basename fixes this, now it works.

btw: very nice project, very useful!