### PR TITLE
make webpdb robust over closing threads

### DIFF
--- a/web_pdb/__init__.py
+++ b/web_pdb/__init__.py
@@ -167,6 +167,7 @@ class WebPdb(Pdb):
             if not self.console.closed:
                 self.console.flush()
                 self.console.close()
+                WebPdb.active_instance = None
         return ret
 
     def get_current_frame_data(self):


### PR DESCRIPTION
This PR addresses [python-web-pdb#18](https://github.com/romanvm/python-web-pdb/issues/18). (Test this branch against my [example script/bug repro instructions here](https://gist.github.com/maiamcc/8081319294438e6bc85c3d7868f914ed#repro-instructions-for-python-web-pdb18).)

Afaict, if you have a `set_trace()` call in a request handler in Django, Python, etc., the webpdb console closes itself when the thread ends (i.e. when the request is done being handled).

However, because it doesn't clear `WebPdb.active_instance = None`, the next time it hits `set_trace()`, it assumes there's an active instance--which break things, because the instance it's looking at doesn't have an active console and so can't actually serve the debugger.

By clearing the active instance on thread-end, we ensure that the next `set_trace()` call, finding no active instance, creates a new one--and in so doing, creates a new (and active) console.

Wanted to put this up for review to see if I'm on the right track. Don't know how I would write a test for this, but I'd love to, if you point me in the right direction.