### PR TITLE
web_console: Make running debugger instance URL more explicit

### DIFF
--- a/web_pdb/web_console.py
+++ b/web_pdb/web_console.py
@@ -103,7 +103,7 @@ class WebConsole:
         self._server_thread = Thread(target=self._run_server, args=(host, port))
         self._server_thread.daemon = True
         logging.critical(
-            'Web-PDB: starting web-server on %s:%s...', gethostname(), port)
+            'Web-PDB: starting web-server, running on http://%s:%s', gethostname(), port)
         self._server_thread.start()
 
     @property


### PR DESCRIPTION
Rewrite the running debugger instance URL in log message to include `http://` prefix, to make it easier to one-click open debugger in web browser from command line or editor/IDE terminal window.

For example:
```
CRITICAL:root:Web-PDB: starting web-server, running on http://myhostname:5555
```

Closes: #51